### PR TITLE
Add tests for as_pipe

### DIFF
--- a/t/22-as_pipe.t
+++ b/t/22-as_pipe.t
@@ -1,0 +1,39 @@
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Test2AndUtils;
+use Crypt::SecretBuffer qw(secret);
+
+subtest 'child receives secret' => sub {
+   my $buf = Crypt::SecretBuffer->new('pipe secret');
+   my $pipe = $buf->as_pipe;
+   pipe(my $parent_r, my $child_w) or die "pipe: $!";
+   my $pid = fork();
+   die "fork: $!" unless defined $pid;
+   if (!$pid) {
+      close $parent_r;
+      local $/;
+      my $got = <$pipe>;
+      print $child_w $got;
+      close $child_w;
+      close $pipe;
+      exit 0;
+   }
+   close $child_w;
+   local $/;
+   my $got = <$parent_r>;
+   is($got, 'pipe secret', 'child got secret');
+   close $parent_r;
+   close $pipe;
+   waitpid($pid, 0);
+};
+
+subtest 'IPC::Run /dev/fd notation' => sub {
+   skip_all('IPC::Run or /dev/fd unsupported')
+      unless eval { require IPC::Run; 1 } && -e '/dev/fd/0';
+   my $buf = Crypt::SecretBuffer->new('ipc run secret');
+   my $echoed = '';
+   IPC::Run::run([ 'cat', '/dev/fd/3' ], '1>', \$echoed, '3<', $buf->as_pipe);
+   is($echoed, 'ipc run secret', 'cat read secret via /dev/fd/3');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary
- add t/22-as_pipe.t to test `as_pipe`
- check that a forked child reads the full secret
- verify IPC::Run `/dev/fd` integration when available

## Testing
- `./dzil-prove t/22-as_pipe.t`
- `./dzil-prove`